### PR TITLE
Feature upgrade to v4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -3,7 +3,7 @@ golang 1.24.2
 golangci-lint 2.10.1
 pre-commit 4.2.0
 regula 3.2.1 # https://github.com/launchbynttdata/asdf-regula
-terraform 1.5.5
+terraform 1.8.2
 terraform-docs 0.20.0
 terragrunt 0.77.22
 tflint 0.57.0

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,28 +1,28 @@
 # Complete example
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~>3.67 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.77, < 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_resource_names"></a> [resource\_names](#module\_resource\_names) | terraform.registry.launch.nttdata.com/module_library/resource_name/launch | ~> 1.0 |
-| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | terraform.registry.launch.nttdata.com/module_primitive/resource_group/azurerm | ~> 1.0 |
-| <a name="module_vnet"></a> [vnet](#module\_vnet) | terraform.registry.launch.nttdata.com/module_primitive/virtual_network/azurerm | ~> 1.0 |
-| <a name="module_private_dns_zone"></a> [private\_dns\_zone](#module\_private\_dns\_zone) | terraform.registry.launch.nttdata.com/module_primitive/private_dns_zone/azurerm | ~> 1.0 |
+| <a name="module_resource_names"></a> [resource\_names](#module\_resource\_names) | terraform.registry.launch.nttdata.com/module_library/resource_name/launch | ~> 2.4 |
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | terraform.registry.launch.nttdata.com/module_primitive/resource_group/azurerm | ~> 1.2 |
+| <a name="module_vnet"></a> [vnet](#module\_vnet) | terraform.registry.launch.nttdata.com/module_primitive/virtual_network/azurerm | ~> 3.2 |
+| <a name="module_private_dns_zone"></a> [private\_dns\_zone](#module\_private\_dns\_zone) | terraform.registry.launch.nttdata.com/module_primitive/private_dns_zone/azurerm | ~> 1.1 |
 | <a name="module_vnet_link"></a> [vnet\_link](#module\_vnet\_link) | ../.. | n/a |
 
 ## Resources
@@ -35,12 +35,12 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_product_family"></a> [product\_family](#input\_product\_family) | (Required) Name of the product family for which the resource is created.<br>    Example: org\_name, department\_name. | `string` | `"dso"` | no |
-| <a name="input_product_service"></a> [product\_service](#input\_product\_service) | (Required) Name of the product service for which the resource is created.<br>    For example, backend, frontend, middleware etc. | `string` | `"kube"` | no |
+| <a name="input_product_family"></a> [product\_family](#input\_product\_family) | (Required) Name of the product family for which the resource is created.<br/>    Example: org\_name, department\_name. | `string` | `"dso"` | no |
+| <a name="input_product_service"></a> [product\_service](#input\_product\_service) | (Required) Name of the product service for which the resource is created.<br/>    For example, backend, frontend, middleware etc. | `string` | `"kube"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment in which the resource should be provisioned like dev, qa, prod etc. | `string` | `"dev"` | no |
 | <a name="input_environment_number"></a> [environment\_number](#input\_environment\_number) | The environment count for the respective environment. Defaults to 000. Increments in value of 1 | `string` | `"000"` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region in which the infra needs to be provisioned | `string` | `"eastus"` | no |
-| <a name="input_resource_names_map"></a> [resource\_names\_map](#input\_resource\_names\_map) | A map of key to resource\_name that will be used by tf-launch-module\_library-resource\_name to generate resource names | <pre>map(object(<br>    {<br>      name       = string<br>      max_length = optional(number, 60)<br>    }<br>  ))</pre> | <pre>{<br>  "rg": {<br>    "max_length": 60,<br>    "name": "rg"<br>  },<br>  "vnet": {<br>    "max_length": 60,<br>    "name": "vnet"<br>  },<br>  "vnet_link": {<br>    "max_length": 60,<br>    "name": "link"<br>  }<br>}</pre> | no |
+| <a name="input_resource_names_map"></a> [resource\_names\_map](#input\_resource\_names\_map) | A map of key to resource\_name that will be used by tf-launch-module\_library-resource\_name to generate resource names | <pre>map(object(<br/>    {<br/>      name       = string<br/>      max_length = optional(number, 60)<br/>    }<br/>  ))</pre> | <pre>{<br/>  "rg": {<br/>    "max_length": 60,<br/>    "name": "rg"<br/>  },<br/>  "vnet": {<br/>    "max_length": 60,<br/>    "name": "vnet"<br/>  },<br/>  "vnet_link": {<br/>    "max_length": 60,<br/>    "name": "link"<br/>  }<br/>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to be associated with the resource | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -52,4 +52,4 @@
 | <a name="output_dns_zone_id"></a> [dns\_zone\_id](#output\_dns\_zone\_id) | n/a |
 | <a name="output_dns_zone_name"></a> [dns\_zone\_name](#output\_dns\_zone\_name) | n/a |
 | <a name="output_vnet_link_id"></a> [vnet\_link\_id](#output\_vnet\_link\_id) | n/a |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -19,7 +19,7 @@ resource "random_integer" "rand_int" {
 
 module "resource_names" {
   source  = "terraform.registry.launch.nttdata.com/module_library/resource_name/launch"
-  version = "~> 1.0"
+  version = "~> 2.4"
 
   for_each = var.resource_names_map
 
@@ -34,7 +34,7 @@ module "resource_names" {
 
 module "resource_group" {
   source  = "terraform.registry.launch.nttdata.com/module_primitive/resource_group/azurerm"
-  version = "~> 1.0"
+  version = "~> 1.2"
 
   name     = module.resource_names["rg"].standard
   location = var.region
@@ -45,26 +45,24 @@ module "resource_group" {
 
 module "vnet" {
   source  = "terraform.registry.launch.nttdata.com/module_primitive/virtual_network/azurerm"
-  version = "~> 1.0"
+  version = "~> 3.2"
 
-  vnet_location                                         = var.region
-  resource_group_name                                   = module.resource_group.name
-  vnet_name                                             = module.resource_names["vnet"].standard
-  address_space                                         = ["10.0.0.0/16"]
-  subnet_names                                          = ["subnet-1", "subnet-2"]
-  subnet_prefixes                                       = ["10.0.5.0/24", "10.0.6.0/24"]
-  bgp_community                                         = null
-  ddos_protection_plan                                  = null
-  dns_servers                                           = []
-  nsg_ids                                               = {}
-  route_tables_ids                                      = {}
-  subnet_delegation                                     = {}
-  subnet_enforce_private_link_endpoint_network_policies = {}
-  subnet_enforce_private_link_service_network_policies  = {}
-  subnet_service_endpoints                              = {}
-  tracing_tags_enabled                                  = false
-  tracing_tags_prefix                                   = ""
-  use_for_each                                          = true
+  vnet_location        = var.region
+  resource_group_name  = module.resource_group.name
+  vnet_name            = module.resource_names["vnet"].standard
+  address_space        = ["10.0.0.0/16"]
+  bgp_community        = null
+  ddos_protection_plan = null
+  dns_servers          = []
+
+  subnets = {
+    subnet-1 = {
+      prefix = "10.0.5.0/24"
+    }
+    subnet-2 = {
+      prefix = "10.0.6.0/24"
+    }
+  }
 
   tags = merge(var.tags, { resource_name = module.resource_names["vnet"].standard })
 
@@ -73,7 +71,7 @@ module "vnet" {
 
 module "private_dns_zone" {
   source  = "terraform.registry.launch.nttdata.com/module_primitive/private_dns_zone/azurerm"
-  version = "~> 1.0"
+  version = "~> 1.1"
 
   resource_group_name = module.resource_group.name
   zone_name           = "example-${random_integer.rand_int.result}.com"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.67"
+      version = ">= 3.77, < 5.0"
     }
 
     random = {

--- a/versions.tf
+++ b/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.67.0"
+      version = ">= 3.77, < 5.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR updates the `complete` example for the private DNS VNet link module to align with the current `virtual_network` v3.x contract and resolves `terraform validate` failures seen in pre-commit.

In addition to example migration, this PR also updates root-level provider/tooling constraints that are release-impacting.

## Changes

1. Updated example module versions:
- `resource_name`: `~> 1.0` -> `~> 2.4`
- `resource_group`: `~> 1.0` -> `~> 1.2`
- `virtual_network`: `~> 1.0` -> `~> 3.2`
- `private_dns_zone`: `~> 1.0` -> `~> 1.1`

2. Migrated VNet input schema in `examples/complete`:
- Removed legacy args no longer supported by `virtual_network` v3.x:
  - `subnet_names`, `subnet_prefixes`
  - `nsg_ids`, `route_tables_ids`
  - `subnet_delegation`
  - `subnet_enforce_private_link_endpoint_network_policies`
  - `subnet_enforce_private_link_service_network_policies`
  - `subnet_service_endpoints`
  - `tracing_tags_enabled`, `tracing_tags_prefix`
  - `use_for_each`
- Added current `subnets` map-based input with explicit subnet prefixes.

3. Updated generated example documentation:
- Refreshed TF docs content to reflect new module/provider versions.
- Standardized TF docs markers to `BEGIN_TF_DOCS` / `END_TF_DOCS`.

4. Updated root provider/tooling constraints:
- Root `versions.tf` provider constraint set to:
  - `azurerm >= 3.77, < 5.0`
- `.tool-versions` Terraform updated:
  - `terraform 1.5.5 -> 1.8.2`

## Validation
- `terraform validate` passed for module root.
- `terraform validate` passed for `examples/complete`.
- `make tfmodule/lint` validate phase now passes for `examples/complete` (previous unsupported argument errors resolved).
- CI is green on current head.

## Breaking Change
This PR should be treated as **major** for release labeling.

While the primitive module interface is unchanged, raising the root provider floor to `azurerm >= 3.77` excludes consumers pinned to older 3.x versions. That is a release-impacting compatibility change for this v4-upgrade batch.

## Compatibility Notes
- Runtime behavior of the primitive resource module is unchanged.
- The `complete` example now matches upstream `virtual_network` v3.x input contract.
- Consumers using `azurerm < 3.77` must upgrade provider version before adopting this release.